### PR TITLE
[SingleNote] Todo template in single note

### DIFF
--- a/src/SingleNote.js
+++ b/src/SingleNote.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { v4 as uuid } from 'uuid';
 
 export function SingleNote({ id, section, notetype, destroyNote, moveSection }) {
   return (
@@ -28,9 +29,7 @@ function NoteContent({ notetype }) {
   if (ntype === 'todo') {
     return (
       <div className="content-todo">
-        <form>
-          <input className="content" type="text" placeholder="This is todo note..."></input>
-        </form>
+        <Todo />
       </div>
     );
   }
@@ -45,4 +44,92 @@ function NoteContent({ notetype }) {
   }
 }
 
+
+function Todo (){
+  const [todos, setTodos] = useState([]);
+
+  const addTodo = (task) => {
+    const todo = {
+      id: uuid(),
+      task
+    };
+
+    const newTodos = [...todos, todo];
+    setTodos(newTodos);
+  };
+  const deleteTodo = (id) => {
+    const newTodos = todos.filter(todo => todo.id !== id);
+    setTodos(newTodos);
+  };
+
+  return (
+    <div>
+      <TodoHeader addTodo={addTodo} />
+      <TodoList todos={todos} deleteTodo={deleteTodo}/>
+    </div>
+  );
+}
+
+function TodoHeader({ addTodo }) {
+  const [value, setValue] = useState('');
+
+  const handleOnChange = (event) => {
+    setValue(event.target.value);
+  };
+
+  const submitTodo = (event) => {
+    if (event.key !== 'Enter')
+      return;
+    addTodo(value);
+    setValue('');
+  };
+
+  return (
+    <header className='todo-header'>
+      <input
+        className='todo-adder'
+        placeholder='Write your task here'
+        value={value}
+        onChange={handleOnChange}
+        onKeyUp={submitTodo}
+        autoFocus />
+    </header>
+  );
+}
+
+function TodoList({ todos = [], deleteTodo}) {
+  return (
+    <ul className="todo-list">
+      {todos.map(todo => (
+        <TodoItem
+          key={todo.id}
+          todo={todo}
+          deleteTodo={deleteTodo} />))}
+    </ul>
+  );
+}
+
+function TodoItem({ todo, deleteTodo }) {
+  const [status, setStatus] = useState('');
+  const {id, task} = todo;
+
+  function toggleStatus(status){
+    status==='complete'? setStatus('incomplete'): setStatus('complete');
+  }
+
+  return (
+    <li className={todo.status}>
+      <input
+        className="complete-check"
+        type="checkbox"
+        checked={status==='complete'}
+        onChange={()=>toggleStatus(status)}
+      />
+      <label>{todo.task}</label>
+      <button
+        className='destroy'
+        onClick={() => deleteTodo(id)} />
+    </li>
+  );
+}
 


### PR DESCRIPTION
- 기존: todo/plain 여부 상관없이 text input form 노출
- 추가 기능
    1) todo note인 경우 todo 컴포넌트 노출, plain인 경우 text input form 노출
    2) todo 내 task 단위로 추가/삭제 가능

![image](https://user-images.githubusercontent.com/62787552/120434932-06c67400-c3b8-11eb-88d5-ff1ea932c2c3.png)
