### PR TITLE
[CSS] Fix the problem where notes are not aligned in a single line

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -36,6 +36,7 @@ section{
   box-shadow: rgba(0, 0, 0, 0.5) 2.5px 2.5px 5px;
   background:  #27303D;
   position: relative;
+  overflow-y: scroll;
 }
 
 .default-note{


### PR DESCRIPTION
노트들이 한 줄로 정렬되지 않던 문제를 해결했습니다! 

기존에는 todoNote가 plainNote보다 아래쪽에 위치하다가 항목을 입력하면 아래의 이미지처럼 위로 올라가는 현상이 발생했었습니다. 
![image](https://user-images.githubusercontent.com/34651994/120911262-c66d3b80-c6c0-11eb-8236-11eb2cd974b3.png)

@heavencandle 님의 조언을 받아(#20) css를 수정하여 아래처럼 todoNote에 항목이 있어도 정렬된 note가 표시되는 UI가 완성되었습니다!
![image](https://user-images.githubusercontent.com/34651994/120911271-f1578f80-c6c0-11eb-97cb-4ec8075c9d5c.png)
